### PR TITLE
Update Starter_notebook.ipynb with v2

### DIFF
--- a/eda-starter-notebook/Starter_notebook.ipynb
+++ b/eda-starter-notebook/Starter_notebook.ipynb
@@ -655,7 +655,7 @@
    "dashboards": [],
    "environmentMetadata": {
     "base_environment": "",
-    "client": "1"
+    "client": "2"
    },
    "language": "python",
    "notebookMetadata": {


### PR DESCRIPTION
We want to use the latest stable version of environment_version in Serverless for better features and performance